### PR TITLE
Example in filters.rst broken

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -124,7 +124,7 @@ equivalent filter creation would look like:
 
     .. code-block:: python
 
-        event_signature_hash = web3.sha3("eventName(uint32)")
+        event_signature_hash = web3.sha3(text="eventName(uint32)").hex()
         event_filter = web3.eth.filter({
             "address": myContract_address,
             "topics": [event_signature_hash,


### PR DESCRIPTION
### What was wrong?

The example of event filtering in filters.rst was broken because `web3.sha3` has changed it's behavior.

It now requires that you specify a `text` parameter to pass a string, and it now returns a HexBytes object instead of a string.

- http://web3py.readthedocs.io/en/stable/overview.html#cryptographic-hashing
- https://github.com/carver/hexbytes/blob/master/hexbytes/main.py

### How was it fixed?

I've updated the example to pass the correct parameters to the sha method and to convert the HexBytes output to a string like the filter topic is expecting.

Before

    event_signature_hash = web3.sha3("eventName(uint32)")

After

    event_signature_hash = web3.sha3(text="eventName(uint32)").hex()

#### Cute Animal Picture

![Swissy Puppy](http://www.senecaswissys.com/uploads/8/5/5/7/8557733/___8680371_orig.jpg)
